### PR TITLE
Read-only user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ ENV POSTGRES_PASSWORD postgres
 ENV POSTGRES_USER postgres
 ENV JDBC_DATABASE_PORT 5060
 ENV POSTGRES_DB db
+ENV READ_ONLY false
 
 # install dependencies (git)
 RUN  apt-get update \
@@ -22,8 +23,12 @@ RUN  apt-get update \
 EXPOSE 5060
 
 COPY clone-data-repo.sh clone-data-repo.sh
+COPY create-read-only-user.sh create-read-only-user.sh
+
 
 # if ssh key is set, clone data repo with the sql scripts for initalization and start postgres afterwards
 CMD chmod 700 clone-data-repo.sh \
     && ./clone-data-repo.sh \
+    && chmod 700 create-read-only-user.sh \
+    && ./create-read-only-user.sh \
     && su postgres -c "/usr/local/bin/docker-entrypoint.sh postgres -p ${JDBC_DATABASE_PORT}"

--- a/create-read-only-user.sh
+++ b/create-read-only-user.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+if [ "$READ_ONLY" = true ] ; then
+
+echo "Create SQL script for read-only-user"
+
+user_name="$POSTGRES_USER"
+user_name+="_read"
+cat >./99-read-only-user.sql <<EOL
+CREATE ROLE readaccess;
+GRANT CONNECT ON DATABASE $POSTGRES_DB TO readaccess;
+GRANT USAGE ON SCHEMA public TO readaccess;
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO readaccess;
+CREATE USER $user_name WITH PASSWORD '$POSTGRES_PASSWORD';
+GRANT readaccess TO $user_name;
+EOL
+
+mv ./99-read-only-user.sql /docker-entrypoint-initdb.d/
+
+fi


### PR DESCRIPTION
This PR adds the functionality to create a read-only user via the READ_ONLY environment variable.
The user name of the read-only user has "_read" as a suffix.

Signed-off-by: Marvin Bechtold <marvin.bechtold.dev@gmail.com>